### PR TITLE
namespace SVG elements

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "purescript-prelude": "^3.0.0",
     "purescript-dom": "^4.3.1",
-    "purescript-smolder": "^10.0.0",
+    "purescript-smolder": "matthewleon/purescript-smolder#namespace",
     "purescript-refs": "^3.0.0",
     "purescript-safely": "^3.0.0",
     "purescript-foldable-traversable": "^3.4.0"

--- a/src/Text/Smolder/Renderer/DOM.js
+++ b/src/Text/Smolder/Renderer/DOM.js
@@ -4,6 +4,14 @@ exports.makeElement = function(name) {
   };
 };
 
+exports.makeElementNS = function(ns) {
+  return function(name) {
+    return function() {
+      return window.document.createElementNS(ns, name);
+    };
+  };
+};
+
 exports.makeText = function(text) {
   return function() {
     return window.document.createTextNode(text);


### PR DESCRIPTION
addresses #2 

Not sure how to do an easy automated test on this... The previous tests were passing, but only checked that the SVG elements ended up in the DOM, not that browsers would actually paint them.

I've QAd locally on a project that needs this. It works.

The dep in `bower.json` is currently pointing to my branch. I can push an update to this if https://github.com/bodil/purescript-smolder/pull/38 is merged.